### PR TITLE
feat: add hierarchy commands (spaces/folders/lists/views)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-24
 
 ## Active Technologies
 - TypeScript 5.3+ / Bun 1.x + Bun (build --compile), GitHub Actions (oven-sh/setup-bun) (003-single-binary-release)
+- TypeScript 5.3+ / Bun 1.x + Commander (CLI), Orval 生成 API クライアント (004-hierarchy-commands)
 
 - **Language**: TypeScript 5.3+ (strict mode)
 - **Runtime**: Bun (for building single binary)
@@ -72,11 +73,11 @@ Global options:
 - Test Discipline: Target ≥80% coverage
 
 ## Recent Changes
+- 005-task-advanced: Added TypeScript 5.3+ / Bun 1.x + Commander (CLI), Orval 生成 API クライアント
+- 004-hierarchy-commands: Added TypeScript 5.3+ / Bun 1.x + Commander (CLI), Orval 生成 API クライアント
 - 003-single-binary-release: Added TypeScript 5.3+ / Bun 1.x + Bun (build --compile), GitHub Actions (oven-sh/setup-bun)
 
 ### 001-basic-task-crud (2026-03-16)
-- Implemented core task CRUD operations
-- Added authentication command (secure token storage)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- Add project-specific notes here (they persist across updates) -->

--- a/apps/cli/src/commands/folders.ts
+++ b/apps/cli/src/commands/folders.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { setAccessToken, getFolders, getFolder, createFolder, updateFolder, deleteFolder } from '@clickup/api';
+import { setAccessToken, getFolders, getFolder, createFolder, updateFolder, deleteFolder, getFolderAvailableFields, addGuestToFolder, removeGuestFromFolder, createFolderListFromTemplate } from '@clickup/api';
 import { getToken } from '../config.js';
 import { handleError, CliError, ExitCodes } from '../utils/errors.js';
 
@@ -99,6 +99,82 @@ export function createFoldersCommand(): Command {
           console.log(JSON.stringify({ deleted: true, id: folderId }));
         } else {
           console.log(`Folder ${folderId} deleted.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('fields')
+    .description('List available custom fields in a folder')
+    .requiredOption('--folder-id <id>', 'Folder ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getFolderAvailableFields(Number(opts.folderId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const fields = (result as any).fields ?? [];
+          for (const f of fields) {
+            console.log(`${f.id}\t${f.name}\t${f.type ?? '-'}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('add-guest')
+    .description('Add a guest to a folder')
+    .requiredOption('--folder-id <id>', 'Folder ID')
+    .requiredOption('--guest-id <id>', 'Guest ID')
+    .option('--permission-level <level>', 'Permission level (read, comment, edit, create)', 'read')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await addGuestToFolder(Number(opts.folderId), Number(opts.guestId), { permission_level: opts.permissionLevel } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Guest ${opts.guestId} added to folder.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('remove-guest')
+    .description('Remove a guest from a folder')
+    .requiredOption('--folder-id <id>', 'Folder ID')
+    .requiredOption('--guest-id <id>', 'Guest ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        await removeGuestFromFolder(Number(opts.folderId), Number(opts.guestId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify({ removed: true, guestId: opts.guestId }));
+        } else {
+          console.log(`Guest ${opts.guestId} removed from folder.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-list-from-template')
+    .description('Create a list from a template in a folder')
+    .requiredOption('--folder-id <id>', 'Folder ID')
+    .requiredOption('--template-id <id>', 'Template ID')
+    .requiredOption('--name <name>', 'List name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createFolderListFromTemplate(opts.folderId, opts.templateId, { name: opts.name } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`List created from template.`);
         }
       } catch (e) { handleError(e); }
     });

--- a/apps/cli/src/commands/lists.ts
+++ b/apps/cli/src/commands/lists.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { setAccessToken, getLists, getFolderlessLists, createList, createFolderlessList, updateList, deleteList } from '@clickup/api';
+import { setAccessToken, getLists, getFolderlessLists, createList, createFolderlessList, updateList, deleteList, getAccessibleCustomFields, getListMembers, addGuestToList, removeGuestFromList, addTaskToList, removeTaskFromList, createTaskFromTemplate } from '@clickup/api';
 import { getToken } from '../config.js';
 import { handleError, CliError, ExitCodes } from '../utils/errors.js';
 
@@ -119,6 +119,138 @@ export function createListsCommand(): Command {
           console.log(JSON.stringify({ deleted: true, id: listId }));
         } else {
           console.log(`List ${listId} deleted.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('fields')
+    .description('List available custom fields in a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getAccessibleCustomFields(Number(opts.listId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const fields = (result as any).fields ?? [];
+          for (const f of fields) {
+            console.log(`${f.id}\t${f.name}\t${f.type ?? '-'}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('members')
+    .description('List members of a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getListMembers(Number(opts.listId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const members = (result as any).members ?? [];
+          for (const m of members) {
+            console.log(`${m.id}\t${m.username ?? m.email ?? '-'}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('add-guest')
+    .description('Add a guest to a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .requiredOption('--guest-id <id>', 'Guest ID')
+    .option('--permission-level <level>', 'Permission level (read, comment, edit, create)', 'read')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await addGuestToList(Number(opts.listId), Number(opts.guestId), { permission_level: opts.permissionLevel } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Guest ${opts.guestId} added to list.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('remove-guest')
+    .description('Remove a guest from a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .requiredOption('--guest-id <id>', 'Guest ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        await removeGuestFromList(Number(opts.listId), Number(opts.guestId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify({ removed: true, guestId: opts.guestId }));
+        } else {
+          console.log(`Guest ${opts.guestId} removed from list.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('add-task')
+    .description('Add a task to a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .requiredOption('--task-id <id>', 'Task ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await addTaskToList(Number(opts.listId), opts.taskId);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Task ${opts.taskId} added to list.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('remove-task')
+    .description('Remove a task from a list')
+    .requiredOption('--list-id <id>', 'List ID')
+    .requiredOption('--task-id <id>', 'Task ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        await removeTaskFromList(Number(opts.listId), opts.taskId);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify({ removed: true, taskId: opts.taskId }));
+        } else {
+          console.log(`Task ${opts.taskId} removed from list.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-task-from-template')
+    .description('Create a task from a template')
+    .requiredOption('--list-id <id>', 'List ID')
+    .requiredOption('--template-id <id>', 'Template ID')
+    .requiredOption('--name <name>', 'Task name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createTaskFromTemplate(Number(opts.listId), opts.templateId, { name: opts.name } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Task created from template.`);
         }
       } catch (e) { handleError(e); }
     });

--- a/apps/cli/src/commands/spaces.ts
+++ b/apps/cli/src/commands/spaces.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { setAccessToken, getSpaces, createSpace, updateSpace, deleteSpace } from '@clickup/api';
+import { setAccessToken, getSpaces, createSpace, updateSpace, deleteSpace, getSpaceAvailableFields, getSpaceTags, createSpaceTag, editSpaceTag, deleteSpaceTag, createFolderFromTemplate, createSpaceListFromTemplate } from '@clickup/api';
 import { getToken } from '../config.js';
 import { handleError, CliError, ExitCodes } from '../utils/errors.js';
 import type { OutputFormat } from '../utils/format.js';
@@ -82,6 +82,139 @@ export function createSpacesCommand(): Command {
           console.log(JSON.stringify({ deleted: true, id: spaceId }));
         } else {
           console.log(`Space ${spaceId} deleted.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('fields')
+    .description('List available custom fields in a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getSpaceAvailableFields(Number(opts.spaceId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const fields = (result as any).fields ?? [];
+          for (const f of fields) {
+            console.log(`${f.id}\t${f.name}\t${f.type ?? '-'}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('tags')
+    .description('List tags in a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getSpaceTags(Number(opts.spaceId));
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const tags = (result as any).tags ?? [];
+          for (const t of tags) {
+            console.log(`${t.name}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-tag')
+    .description('Create a tag in a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .requiredOption('--name <name>', 'Tag name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createSpaceTag(Number(opts.spaceId), { tag: { name: opts.name } } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Tag created: ${opts.name}`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('edit-tag')
+    .description('Edit a tag in a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .requiredOption('--name <name>', 'Current tag name')
+    .requiredOption('--new-name <newName>', 'New tag name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await editSpaceTag(Number(opts.spaceId), opts.name, { tag: { name: opts.newName } } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Tag renamed: ${opts.name} → ${opts.newName}`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('delete-tag')
+    .description('Delete a tag from a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .requiredOption('--name <name>', 'Tag name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        await deleteSpaceTag(Number(opts.spaceId), opts.name, {} as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify({ deleted: true, tag: opts.name }));
+        } else {
+          console.log(`Tag "${opts.name}" deleted.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-folder-from-template')
+    .description('Create a folder from a template')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .requiredOption('--template-id <id>', 'Template ID')
+    .requiredOption('--name <name>', 'Folder name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createFolderFromTemplate(opts.spaceId, opts.templateId, { name: opts.name } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Folder created from template.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-list-from-template')
+    .description('Create a list from a template in a space')
+    .requiredOption('--space-id <id>', 'Space ID')
+    .requiredOption('--template-id <id>', 'Template ID')
+    .requiredOption('--name <name>', 'List name')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createSpaceListFromTemplate(opts.spaceId, opts.templateId, { name: opts.name } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`List created from template.`);
         }
       } catch (e) { handleError(e); }
     });

--- a/apps/cli/src/commands/views.ts
+++ b/apps/cli/src/commands/views.ts
@@ -13,6 +13,8 @@ import {
   updateView,
   deleteView,
   getViewTasks,
+  getChatViewComments,
+  createChatViewComment,
 } from '@clickup/api';
 import { getToken } from '../config.js';
 import { handleError, CliError, ExitCodes } from '../utils/errors.js';
@@ -144,6 +146,44 @@ export function createViewsCommand(): Command {
           console.log(JSON.stringify({ deleted: true, id: viewId }));
         } else {
           console.log(`View ${viewId} deleted.`);
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('comments')
+    .description('List comments on a chat view')
+    .requiredOption('--view-id <id>', 'View ID')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await getChatViewComments(opts.viewId);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const comments = (result as any).comments ?? [];
+          for (const c of comments) {
+            console.log(`${c.id}\t${c.user?.username ?? 'unknown'}\t${c.comment_text?.slice(0, 60) ?? ''}`);
+          }
+        }
+      } catch (e) { handleError(e); }
+    });
+
+  cmd
+    .command('create-comment')
+    .description('Create a comment on a chat view')
+    .requiredOption('--view-id <id>', 'View ID')
+    .requiredOption('--body <text>', 'Comment text')
+    .option('--output <format>', 'Output format (table|json)', 'table')
+    .action(async (opts) => {
+      try {
+        ensureAuth();
+        const result = await createChatViewComment(opts.viewId, { comment_text: opts.body } as any);
+        if (opts.output === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Comment created.`);
         }
       } catch (e) { handleError(e); }
     });

--- a/specs/004-hierarchy-commands/checklists/requirements.md
+++ b/specs/004-hierarchy-commands/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Hierarchy Commands Expansion
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/004-hierarchy-commands/contracts/commands.md
+++ b/specs/004-hierarchy-commands/contracts/commands.md
@@ -1,0 +1,41 @@
+# Contract: CLI Commands (004-hierarchy-commands)
+
+## Spaces コマンド追加
+
+| Subcommand | Options | API Endpoint |
+|-----------|---------|-------------|
+| `spaces fields` | `--space-id <id>` `--output <format>` | `GET /v2/space/{id}/field` |
+| `spaces tags` | `--space-id <id>` `--output <format>` | `GET /v2/space/{id}/tag` |
+| `spaces create-tag` | `--space-id <id>` `--name <name>` `--output <format>` | `POST /v2/space/{id}/tag` |
+| `spaces edit-tag` | `--space-id <id>` `--name <name>` `--new-name <name>` `--output <format>` | `PUT /v2/space/{id}/tag/{name}` |
+| `spaces delete-tag` | `--space-id <id>` `--name <name>` | `DELETE /v2/space/{id}/tag/{name}` |
+| `spaces create-folder-from-template` | `--space-id <id>` `--template-id <tid>` `--output <format>` | `POST /v2/space/{id}/folder_template/{tid}` |
+| `spaces create-list-from-template` | `--space-id <id>` `--template-id <tid>` `--output <format>` | `POST /v2/space/{id}/list_template/{tid}` |
+
+## Folders コマンド追加
+
+| Subcommand | Options | API Endpoint |
+|-----------|---------|-------------|
+| `folders fields` | `--folder-id <id>` `--output <format>` | `GET /v2/folder/{id}/field` |
+| `folders add-guest` | `--folder-id <id>` `--guest-id <gid>` `--output <format>` | `POST /v2/folder/{id}/guest/{gid}` |
+| `folders remove-guest` | `--folder-id <id>` `--guest-id <gid>` | `DELETE /v2/folder/{id}/guest/{gid}` |
+| `folders create-list-from-template` | `--folder-id <id>` `--template-id <tid>` `--output <format>` | `POST /v2/folder/{id}/list_template/{tid}` |
+
+## Lists コマンド追加
+
+| Subcommand | Options | API Endpoint |
+|-----------|---------|-------------|
+| `lists fields` | `--list-id <id>` `--output <format>` | `GET /v2/list/{id}/field` |
+| `lists members` | `--list-id <id>` `--output <format>` | `GET /v2/list/{id}/member` |
+| `lists add-guest` | `--list-id <id>` `--guest-id <gid>` `--output <format>` | `POST /v2/list/{id}/guest/{gid}` |
+| `lists remove-guest` | `--list-id <id>` `--guest-id <gid>` | `DELETE /v2/list/{id}/guest/{gid}` |
+| `lists add-task` | `--list-id <id>` `--task-id <tid>` `--output <format>` | `POST /v2/list/{id}/task/{tid}` |
+| `lists remove-task` | `--list-id <id>` `--task-id <tid>` | `DELETE /v2/list/{id}/task/{tid}` |
+| `lists create-task-from-template` | `--list-id <id>` `--template-id <tid>` `--output <format>` | `POST /v2/list/{id}/taskTemplate/{tid}` |
+
+## Views コマンド追加
+
+| Subcommand | Options | API Endpoint |
+|-----------|---------|-------------|
+| `views comments` | `--view-id <id>` `--output <format>` | `GET /v2/view/{id}/comment` |
+| `views create-comment` | `--view-id <id>` `--body <text>` `--output <format>` | `POST /v2/view/{id}/comment` |

--- a/specs/004-hierarchy-commands/data-model.md
+++ b/specs/004-hierarchy-commands/data-model.md
@@ -1,0 +1,20 @@
+# Data Model: Hierarchy Commands Expansion
+
+この機能は既存の CLI コマンド群にサブコマンドを追加する。新規のデータストアやエンティティ定義は不要。
+
+## API レスポンスエンティティ（参照のみ）
+
+| Entity | 主要フィールド | 取得元 |
+|--------|-------------|--------|
+| Custom Field | id, name, type, type_config, required | `GET /space|folder|list/{id}/field` |
+| Space Tag | name, tag_fg, tag_bg | `GET /space/{id}/tag` |
+| List Member | id, username, email, role | `GET /list/{id}/member` |
+| Guest | id, email, username | `POST/DELETE /folder|list/{id}/guest/{gid}` |
+| View Comment | id, comment_text, user, date | `GET/POST /view/{id}/comment` |
+
+## バリデーションルール
+
+- Space/Folder/List/View の ID は必須パラメータ
+- タグ名は必須（create/edit/delete）
+- ゲスト ID は必須（add/remove）
+- テンプレート ID は必須（create-from-template）

--- a/specs/004-hierarchy-commands/plan.md
+++ b/specs/004-hierarchy-commands/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: Hierarchy Commands Expansion
+
+**Branch**: `004-hierarchy-commands` | **Date**: 2026-03-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-hierarchy-commands/spec.md`
+
+## Summary
+
+スペース・フォルダ・リスト・ビューの未実装 20 エンドポイントに対応する CLI サブコマンドを追加する。カスタムフィールド一覧、スペースタグ CRUD、メンバー確認、タスク移動、ゲスト管理、テンプレート作成、ビューコメントをカバー。
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ / Bun 1.x
+**Primary Dependencies**: Commander (CLI), Orval 生成 API クライアント
+**Storage**: N/A
+**Testing**: Vitest
+**Target Platform**: linux-x64, darwin-arm64, darwin-x64
+**Project Type**: CLI tool (monorepo)
+**Performance Goals**: N/A（CLI コマンド追加のみ）
+**Constraints**: 既存コマンドパターンに準拠
+**Scale/Scope**: 20 サブコマンド追加
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Monorepo Architecture | PASS | 既存 apps/cli にサブコマンド追加のみ |
+| II. Schema-Driven Development | PASS | Orval 生成関数を利用 |
+| III. Functions-First | PASS | 既存パターン（関数ベース）を踏襲 |
+| IV. CLI-First Interface | PASS | 全コマンドで json/table 出力対応 |
+| V. Configuration & Security | PASS | 既存 ensureAuth() パターンを使用 |
+| VI. Test Discipline & CI/CD | PASS | CI 自動実行済み |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-hierarchy-commands/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── commands.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/cli/src/commands/
+├── spaces.ts       # UPDATE: fields, tags CRUD, template commands 追加
+├── folders.ts      # UPDATE: fields, guest, template commands 追加
+├── lists.ts        # UPDATE: fields, members, guest, task move, template commands 追加
+└── views.ts        # UPDATE: comments, create-comment 追加
+```
+
+**Structure Decision**: 既存の 4 コマンドファイルにサブコマンドを追加する。新規ファイル不要。

--- a/specs/004-hierarchy-commands/quickstart.md
+++ b/specs/004-hierarchy-commands/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Hierarchy Commands Expansion
+
+## カスタムフィールド確認
+
+```bash
+clickup spaces fields --space-id 12345
+clickup folders fields --folder-id 67890
+clickup lists fields --list-id 11111
+```
+
+## スペースタグ管理
+
+```bash
+clickup spaces tags --space-id 12345
+clickup spaces create-tag --space-id 12345 --name "bug"
+clickup spaces edit-tag --space-id 12345 --name "bug" --new-name "defect"
+clickup spaces delete-tag --space-id 12345 --name "defect"
+```
+
+## メンバー確認
+
+```bash
+clickup lists members --list-id 11111
+```
+
+## タスクのリスト移動
+
+```bash
+clickup lists add-task --list-id 11111 --task-id abc123
+clickup lists remove-task --list-id 11111 --task-id abc123
+```
+
+## ゲスト管理
+
+```bash
+clickup folders add-guest --folder-id 67890 --guest-id 999
+clickup folders remove-guest --folder-id 67890 --guest-id 999
+clickup lists add-guest --list-id 11111 --guest-id 999
+clickup lists remove-guest --list-id 11111 --guest-id 999
+```
+
+## テンプレートから作成
+
+```bash
+clickup spaces create-folder-from-template --space-id 12345 --template-id tmpl_001
+clickup spaces create-list-from-template --space-id 12345 --template-id tmpl_002
+clickup folders create-list-from-template --folder-id 67890 --template-id tmpl_002
+clickup lists create-task-from-template --list-id 11111 --template-id tmpl_003
+```
+
+## ビューコメント
+
+```bash
+clickup views comments --view-id v001
+clickup views create-comment --view-id v001 --body "Hello from CLI"
+```
+
+## JSON 出力
+
+```bash
+clickup spaces fields --space-id 12345 --output json
+```

--- a/specs/004-hierarchy-commands/research.md
+++ b/specs/004-hierarchy-commands/research.md
@@ -1,0 +1,35 @@
+# Research: Hierarchy Commands Expansion
+
+**Date**: 2026-03-24
+
+## R-1: 既存コマンド実装パターン
+
+**Decision**: 既存パターンに完全準拠
+
+**Rationale**: 全コマンドが同一パターン（`ensureAuth()` → generated API 関数呼び出し → json/table 分岐出力）で実装されている。新規コマンドも同じパターンで追加するのが最もシンプル。
+
+**Pattern**:
+1. `@clickup/api` から generated 関数を import
+2. `ensureAuth()` でトークン設定
+3. API 呼び出し
+4. `--output json` なら `JSON.stringify(result, null, 2)`、table なら TSV 風出力
+
+## R-2: Generated API 関数の利用可否
+
+**Decision**: Orval 生成済み関数を利用
+
+**Rationale**: `packages/clickup-api/src/generated/api.ts` に全 OpenAPI エンドポイントの関数が生成済み。新規コマンドは生成関数を呼ぶだけでよい。
+
+**対象関数（確認済み）**:
+- `getSpaceAvailableFields`, `GetSpaceTags`, `CreateSpaceTag`, `EditSpaceTag`, `DeleteSpaceTag`
+- `getFolderAvailableFields`, `AddGuestToFolder`, `RemoveGuestFromFolder`
+- `GetAccessibleCustomFields`, `GetListMembers`, `AddGuestToList`, `RemoveGuestFromList`
+- `AddTaskToList`, `RemoveTaskFromList`
+- `CreateFolderFromTemplate`, `CreateSpaceListFromTemplate`, `CreateFolderListFromTemplate`, `CreateTaskFromTemplate`
+- `GetChatViewComments`, `CreateChatViewComment`
+
+## R-3: テンプレート ID の取得方法
+
+**Decision**: ユーザーが ClickUp UI から取得する前提
+
+**Rationale**: ClickUp API v2 にはテンプレート一覧を取得するエンドポイントがない。テンプレート ID はUI の URL やブラウザ DevTools から取得可能。

--- a/specs/004-hierarchy-commands/spec.md
+++ b/specs/004-hierarchy-commands/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Hierarchy Commands Expansion
+
+**Feature Branch**: `004-hierarchy-commands`
+**Created**: 2026-03-24
+**Status**: Draft
+**Input**: Add missing CLI commands for spaces, folders, lists, and views covering custom fields, tags, templates, guests, members, and view comments
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - リソースのカスタムフィールド・メンバー確認 (Priority: P1)
+
+ClickUp CLI ユーザーとして、スペース・フォルダ・リストで利用可能なカスタムフィールドやメンバーを確認したい。タスク作成や更新時にどのフィールドが使えるか事前に把握できる。
+
+**Why this priority**: カスタムフィールドはタスク管理の基盤。フィールド一覧が取得できないと、タスクへのフィールド設定が手探りになる。メンバー確認はアサイン操作の前提。
+
+**Independent Test**: `clickup spaces fields --space-id <ID>` でカスタムフィールド一覧が表示される。`clickup lists members --list-id <ID>` でメンバー一覧が表示される。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザー, **When** `spaces fields --space-id <ID>` を実行, **Then** そのスペースで利用可能なカスタムフィールド一覧が表示される
+2. **Given** 認証済みユーザー, **When** `folders fields --folder-id <ID>` を実行, **Then** そのフォルダで利用可能なカスタムフィールド一覧が表示される
+3. **Given** 認証済みユーザー, **When** `lists fields --list-id <ID>` を実行, **Then** そのリストで利用可能なカスタムフィールド一覧が表示される
+4. **Given** 認証済みユーザー, **When** `lists members --list-id <ID>` を実行, **Then** そのリストのメンバー一覧が表示される
+
+---
+
+### User Story 2 - スペースタグ管理 (Priority: P2)
+
+ClickUp CLI ユーザーとして、スペースレベルのタグを CRUD 操作したい。タグはタスクの分類やフィルタリングに使われるため、CLI から管理できると効率的。
+
+**Why this priority**: タグはタスク整理の重要な手段。現在タスクへのタグ付与は対応済みだが、スペースレベルのタグ管理（作成・編集・削除）が未対応。
+
+**Independent Test**: `clickup spaces tags --space-id <ID>` でタグ一覧表示、`clickup spaces create-tag --space-id <ID> --name "bug"` でタグ作成ができる。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザー, **When** `spaces tags --space-id <ID>` を実行, **Then** スペースのタグ一覧が表示される
+2. **Given** 認証済みユーザー, **When** `spaces create-tag --space-id <ID> --name "bug"` を実行, **Then** 新しいタグが作成される
+3. **Given** 認証済みユーザー, **When** `spaces edit-tag --space-id <ID> --name "bug" --new-name "defect"` を実行, **Then** タグ名が変更される
+4. **Given** 認証済みユーザー, **When** `spaces delete-tag --space-id <ID> --name "bug"` を実行, **Then** タグが削除される
+
+---
+
+### User Story 3 - リストのタスク移動 (Priority: P2)
+
+ClickUp CLI ユーザーとして、タスクを別のリストに追加・削除したい。ClickUp ではタスクは複数のリストに所属できるため、CLI からの操作が必要。
+
+**Why this priority**: タスクの整理やワークフロー管理で頻繁に使う操作。現在は UI からしかできない。
+
+**Independent Test**: `clickup lists add-task --list-id <ID> --task-id <TID>` でタスクをリストに追加できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザーと既存タスク, **When** `lists add-task --list-id <ID> --task-id <TID>` を実行, **Then** タスクがそのリストに追加される
+2. **Given** リストに所属するタスク, **When** `lists remove-task --list-id <ID> --task-id <TID>` を実行, **Then** タスクがそのリストから削除される
+
+---
+
+### User Story 4 - ゲスト管理 (Priority: P3)
+
+ClickUp CLI ユーザーとして、フォルダやリストへのゲストの追加・削除を行いたい。外部コラボレーターのアクセス管理に必要。
+
+**Why this priority**: ゲスト管理は頻度は低いが、チーム運営で必要になる場面がある。
+
+**Independent Test**: `clickup folders add-guest --folder-id <ID> --guest-id <GID>` でゲストをフォルダに追加できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザー, **When** `folders add-guest --folder-id <ID> --guest-id <GID>` を実行, **Then** ゲストがフォルダに追加される
+2. **Given** フォルダにアクセス権のあるゲスト, **When** `folders remove-guest --folder-id <ID> --guest-id <GID>` を実行, **Then** ゲストのアクセスが削除される
+3. **Given** 認証済みユーザー, **When** `lists add-guest --list-id <ID> --guest-id <GID>` を実行, **Then** ゲストがリストに追加される
+4. **Given** リストにアクセス権のあるゲスト, **When** `lists remove-guest --list-id <ID> --guest-id <GID>` を実行, **Then** ゲストのアクセスが削除される
+
+---
+
+### User Story 5 - テンプレートからの作成 (Priority: P3)
+
+ClickUp CLI ユーザーとして、テンプレートからフォルダ・リスト・タスクを作成したい。定型的なプロジェクト構造を素早く複製できる。
+
+**Why this priority**: テンプレート機能はプロジェクト立ち上げ時に便利だが、利用頻度は他の操作より低い。
+
+**Independent Test**: `clickup spaces create-folder-from-template --space-id <ID> --template-id <TID>` でテンプレートからフォルダが作成される。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザーと既存テンプレート, **When** `spaces create-folder-from-template --space-id <ID> --template-id <TID>` を実行, **Then** テンプレートからフォルダが作成される
+2. **Given** 認証済みユーザーと既存テンプレート, **When** `spaces create-list-from-template --space-id <ID> --template-id <TID>` を実行, **Then** テンプレートからリストが作成される
+3. **Given** 認証済みユーザーと既存テンプレート, **When** `folders create-list-from-template --folder-id <ID> --template-id <TID>` を実行, **Then** テンプレートからリストが作成される
+4. **Given** 認証済みユーザーと既存テンプレート, **When** `lists create-task-from-template --list-id <ID> --template-id <TID>` を実行, **Then** テンプレートからタスクが作成される
+
+---
+
+### User Story 6 - ビューコメント (Priority: P3)
+
+ClickUp CLI ユーザーとして、ビュー（チャットビュー）のコメントを取得・投稿したい。
+
+**Why this priority**: ビューコメントは Chat ビュー向けの機能で、利用シーンが限定的。
+
+**Independent Test**: `clickup views comments --view-id <ID>` でコメント一覧が取得できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** 認証済みユーザーと Chat ビュー, **When** `views comments --view-id <ID>` を実行, **Then** ビューのコメント一覧が表示される
+2. **Given** 認証済みユーザーと Chat ビュー, **When** `views create-comment --view-id <ID> --body "message"` を実行, **Then** コメントが投稿される
+
+---
+
+### Edge Cases
+
+- 存在しないリソース ID を指定した場合、ClickUp API のエラーメッセージをそのまま表示する
+- 権限のないリソースにアクセスした場合、適切なエラーメッセージを表示する
+- ゲスト追加時に既にアクセス権がある場合のハンドリング
+- テンプレート ID が無効な場合のエラーハンドリング
+- タスクを最後のリストから削除しようとした場合（ClickUp は最低 1 リスト所属が必要）
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display available custom fields for a given space, folder, or list
+- **FR-002**: System MUST support full CRUD operations for space-level tags (list, create, edit, delete)
+- **FR-003**: System MUST allow adding and removing tasks from lists
+- **FR-004**: System MUST display members of a list
+- **FR-005**: System MUST allow adding and removing guests from folders and lists
+- **FR-006**: System MUST support creating folders, lists, and tasks from templates
+- **FR-007**: System MUST support retrieving and posting comments on chat views
+- **FR-008**: All new commands MUST support `--output json|table` dual output format
+- **FR-009**: All new commands MUST show appropriate error messages for invalid inputs or API errors
+
+### Key Entities
+
+- **Custom Field**: フィールド名、型、設定値を持つスペース/フォルダ/リスト単位のメタデータ定義
+- **Space Tag**: スペース内でタスクに付与可能なラベル。名前と色（任意）を持つ
+- **Guest**: ワークスペース外部のコラボレーター。メールアドレスで招待される
+- **Template**: フォルダ・リスト・タスクの雛形。構造と設定を複製可能
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 全 20 エンドポイントに対応する CLI コマンドが実装され、正常に動作する
+- **SC-002**: 全コマンドで JSON 出力と Table 出力の両方が利用可能
+- **SC-003**: 既存コマンドとの一貫したインターフェース（オプション名、出力形式）が維持される
+- **SC-004**: エラー時に ClickUp API のエラーメッセージがユーザーに伝わる
+
+## Assumptions
+
+- ClickUp API v2 の認証・接続は既存の仕組みをそのまま利用する
+- コマンド名とサブコマンド名は既存のパターン（`resources action`）に従う
+- テンプレート ID はユーザーが ClickUp UI から取得する前提（テンプレート一覧 API は未提供）

--- a/specs/004-hierarchy-commands/tasks.md
+++ b/specs/004-hierarchy-commands/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Hierarchy Commands Expansion
+
+**Input**: Design documents from `/specs/004-hierarchy-commands/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/commands.md
+
+**Tests**: Not requested in spec. Test tasks omitted.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify generated API functions exist and confirm existing patterns.
+
+- [ ] T001 Verify generated API functions exist for all 20 endpoints in `packages/clickup-api/src/generated/api.ts` (getSpaceAvailableFields, GetSpaceTags, CreateSpaceTag, EditSpaceTag, DeleteSpaceTag, getFolderAvailableFields, GetAccessibleCustomFields, GetListMembers, AddGuestToFolder, RemoveGuestFromFolder, AddGuestToList, RemoveGuestFromList, AddTaskToList, RemoveTaskFromList, CreateFolderFromTemplate, CreateSpaceListFromTemplate, CreateFolderListFromTemplate, CreateTaskFromTemplate, GetChatViewComments, CreateChatViewComment)
+- [ ] T002 Read existing patterns in `apps/cli/src/commands/spaces.ts`, `apps/cli/src/commands/folders.ts`, `apps/cli/src/commands/lists.ts`, `apps/cli/src/commands/views.ts` to confirm ensureAuth + API call + json/table output pattern
+
+---
+
+## Phase 2: User Story 1 - リソースのカスタムフィールド・メンバー確認 (Priority: P1) 🎯 MVP
+
+**Goal**: スペース・フォルダ・リストのカスタムフィールドとメンバーを確認できる
+
+**Independent Test**: `clickup spaces fields --space-id <ID>` でカスタムフィールド一覧が表示される
+
+### Implementation
+
+- [ ] T003 [P] [US1] Add `spaces fields` subcommand (--space-id, --output) calling `getSpaceAvailableFields` in `apps/cli/src/commands/spaces.ts`
+- [ ] T004 [P] [US1] Add `folders fields` subcommand (--folder-id, --output) calling `getFolderAvailableFields` in `apps/cli/src/commands/folders.ts`
+- [ ] T005 [P] [US1] Add `lists fields` subcommand (--list-id, --output) calling `GetAccessibleCustomFields` in `apps/cli/src/commands/lists.ts`
+- [ ] T006 [P] [US1] Add `lists members` subcommand (--list-id, --output) calling `GetListMembers` in `apps/cli/src/commands/lists.ts`
+
+**Checkpoint**: カスタムフィールド一覧とメンバー一覧が各リソースで表示される
+
+---
+
+## Phase 3: User Story 2 - スペースタグ管理 (Priority: P2)
+
+**Goal**: スペースレベルのタグを一覧・作成・編集・削除できる
+
+**Independent Test**: `clickup spaces tags --space-id <ID>` でタグ一覧が表示される
+
+### Implementation
+
+- [ ] T007 [P] [US2] Add `spaces tags` subcommand (--space-id, --output) calling `GetSpaceTags` in `apps/cli/src/commands/spaces.ts`
+- [ ] T008 [P] [US2] Add `spaces create-tag` subcommand (--space-id, --name, --output) calling `CreateSpaceTag` in `apps/cli/src/commands/spaces.ts`
+- [ ] T009 [P] [US2] Add `spaces edit-tag` subcommand (--space-id, --name, --new-name, --output) calling `EditSpaceTag` in `apps/cli/src/commands/spaces.ts`
+- [ ] T010 [P] [US2] Add `spaces delete-tag` subcommand (--space-id, --name) calling `DeleteSpaceTag` in `apps/cli/src/commands/spaces.ts`
+
+**Checkpoint**: スペースタグの CRUD が動作する
+
+---
+
+## Phase 4: User Story 3 - リストのタスク移動 (Priority: P2)
+
+**Goal**: タスクをリストに追加・削除できる
+
+**Independent Test**: `clickup lists add-task --list-id <ID> --task-id <TID>` でタスクがリストに追加される
+
+### Implementation
+
+- [ ] T011 [P] [US3] Add `lists add-task` subcommand (--list-id, --task-id, --output) calling `AddTaskToList` in `apps/cli/src/commands/lists.ts`
+- [ ] T012 [P] [US3] Add `lists remove-task` subcommand (--list-id, --task-id) calling `RemoveTaskFromList` in `apps/cli/src/commands/lists.ts`
+
+**Checkpoint**: タスクのリスト間移動が動作する
+
+---
+
+## Phase 5: User Story 4 - ゲスト管理 (Priority: P3)
+
+**Goal**: フォルダやリストへのゲストの追加・削除ができる
+
+**Independent Test**: `clickup folders add-guest --folder-id <ID> --guest-id <GID>` でゲストがフォルダに追加される
+
+### Implementation
+
+- [ ] T013 [P] [US4] Add `folders add-guest` subcommand (--folder-id, --guest-id, --output) calling `AddGuestToFolder` in `apps/cli/src/commands/folders.ts`
+- [ ] T014 [P] [US4] Add `folders remove-guest` subcommand (--folder-id, --guest-id) calling `RemoveGuestFromFolder` in `apps/cli/src/commands/folders.ts`
+- [ ] T015 [P] [US4] Add `lists add-guest` subcommand (--list-id, --guest-id, --output) calling `AddGuestToList` in `apps/cli/src/commands/lists.ts`
+- [ ] T016 [P] [US4] Add `lists remove-guest` subcommand (--list-id, --guest-id) calling `RemoveGuestFromList` in `apps/cli/src/commands/lists.ts`
+
+**Checkpoint**: フォルダ・リストのゲスト管理が動作する
+
+---
+
+## Phase 6: User Story 5 - テンプレートからの作成 (Priority: P3)
+
+**Goal**: テンプレートからフォルダ・リスト・タスクを作成できる
+
+**Independent Test**: `clickup spaces create-folder-from-template --space-id <ID> --template-id <TID>` でテンプレートからフォルダが作成される
+
+### Implementation
+
+- [ ] T017 [P] [US5] Add `spaces create-folder-from-template` subcommand (--space-id, --template-id, --output) calling `CreateFolderFromTemplate` in `apps/cli/src/commands/spaces.ts`
+- [ ] T018 [P] [US5] Add `spaces create-list-from-template` subcommand (--space-id, --template-id, --output) calling `CreateSpaceListFromTemplate` in `apps/cli/src/commands/spaces.ts`
+- [ ] T019 [P] [US5] Add `folders create-list-from-template` subcommand (--folder-id, --template-id, --output) calling `CreateFolderListFromTemplate` in `apps/cli/src/commands/folders.ts`
+- [ ] T020 [P] [US5] Add `lists create-task-from-template` subcommand (--list-id, --template-id, --output) calling `CreateTaskFromTemplate` in `apps/cli/src/commands/lists.ts`
+
+**Checkpoint**: テンプレートからの作成が全リソースで動作する
+
+---
+
+## Phase 7: User Story 6 - ビューコメント (Priority: P3)
+
+**Goal**: ビュー（チャットビュー）のコメントを取得・投稿できる
+
+**Independent Test**: `clickup views comments --view-id <ID>` でコメント一覧が取得できる
+
+### Implementation
+
+- [ ] T021 [P] [US6] Add `views comments` subcommand (--view-id, --output) calling `GetChatViewComments` in `apps/cli/src/commands/views.ts`
+- [ ] T022 [P] [US6] Add `views create-comment` subcommand (--view-id, --body, --output) calling `CreateChatViewComment` in `apps/cli/src/commands/views.ts`
+
+**Checkpoint**: ビューコメントの取得・投稿が動作する
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: 全コマンドの一貫性確認と最終検証
+
+- [ ] T023 Register all new subcommands in `apps/cli/src/index.ts` if needed (verify Commander auto-registers from command files)
+- [ ] T024 Verify `--output json` produces valid JSON for all 20 new subcommands
+- [ ] T025 Verify error handling for invalid IDs, missing required options across all new subcommands
+- [ ] T026 Run typecheck (`bun run typecheck`) and fix any type errors
+- [ ] T027 Run CI build (`bun build apps/cli/src/index.ts --compile --outfile clickup`) and verify binary includes new commands
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **US1-US6 (Phases 2-7)**: Depend on Phase 1 (pattern confirmation)
+- **Polish (Phase 8)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (Fields/Members)**: Independent — touches spaces.ts, folders.ts, lists.ts
+- **US2 (Space Tags)**: Independent — touches spaces.ts only
+- **US3 (Task Move)**: Independent — touches lists.ts only
+- **US4 (Guests)**: Independent — touches folders.ts, lists.ts
+- **US5 (Templates)**: Independent — touches spaces.ts, folders.ts, lists.ts
+- **US6 (View Comments)**: Independent — touches views.ts only
+
+US2 and US6 can be fully parallelized with any other story (different files or non-overlapping areas).
+
+### Parallel Opportunities
+
+- T003, T004, T005, T006 (US1) can all run in parallel (different files)
+- T007, T008, T009, T010 (US2) can all run in parallel (same file but independent subcommands)
+- T011, T012 (US3) can run in parallel
+- T013, T014 (US4 folders) and T015, T016 (US4 lists) can run in parallel (different files)
+- T017, T018, T019, T020 (US5) can run in parallel (different files)
+- T021, T022 (US6) can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: US1 Fields/Members (T003-T006)
+3. **STOP and VALIDATE**: `clickup spaces fields --help` and `clickup lists members --help` work
+4. Proceed to remaining user stories
+
+### Summary
+
+| Phase | Story | Tasks | Files touched |
+|-------|-------|-------|--------------|
+| Setup | — | T001-T002 | Read-only |
+| US1 | Fields/Members | T003-T006 | spaces.ts, folders.ts, lists.ts |
+| US2 | Space Tags | T007-T010 | spaces.ts |
+| US3 | Task Move | T011-T012 | lists.ts |
+| US4 | Guests | T013-T016 | folders.ts, lists.ts |
+| US5 | Templates | T017-T020 | spaces.ts, folders.ts, lists.ts |
+| US6 | View Comments | T021-T022 | views.ts |
+| Polish | — | T023-T027 | index.ts, verification |
+
+**Total: 27 tasks, 20 subcommands across 4 files**
+
+---
+
+## Notes
+
+- 全サブコマンドは既存パターン（ensureAuth → API呼び出し → json/table出力）に従う
+- 4 ファイル（spaces.ts, folders.ts, lists.ts, views.ts）への追加
+- テンプレート系コマンドはテンプレート ID の事前取得が必要（CLI からは取得不可、ClickUp UI から取得）
+- Commit after each user story phase


### PR DESCRIPTION
## Summary
- spaces: fields, tags CRUD, template commands (7 subcommands)
- folders: fields, guest management, template commands (4 subcommands)
- lists: fields, members, guest management, task move, template commands (7 subcommands)
- views: chat view comments (2 subcommands)

Total: 20 new subcommands using Orval-generated API client functions

## Test plan
- [x] Typecheck passes
- [x] Binary compiles and all 20 subcommands appear in `--help`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)