### PR TITLE
ci: enable integration tests in CI with API token secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,14 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Test
+      - name: Unit tests
         run: bunx vitest run --passWithNoTests --exclude='**/integration.test.ts'
+
+      - name: Integration tests
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
+        run: bunx vitest run --passWithNoTests 'packages/**/*.integration.test.ts' '**/integration.test.ts'
 
       - name: Build (compile check)
         run: bun build apps/cli/src/index.ts --compile --outfile clickup


### PR DESCRIPTION
## Summary
- `CLICKUP_API_TOKEN` を repository secret に設定
- CI に integration test ステップを追加（unit test とは分離）
- fork PR ではシークレットが使えないため、same-repo PR と push to main のみで実行

Closes #16

## Test plan
- [ ] CI で unit test が通ること
- [ ] CI で integration test が通ること（secret 利用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)