### PR TITLE
feat: add CLI-level space/team access restriction

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { encrypt, decrypt, type EncryptedData } from './crypto.js';
+import { CliError, ExitCodes } from './utils/errors.js';
 
 // XDG-compliant config directory
 const CONFIG_DIR = process.env.XDG_CONFIG_HOME
@@ -19,6 +20,8 @@ const LEGACY_CONFIG_FILE = join(LEGACY_CONFIG_DIR, 'config.json');
 export interface AppConfig {
   default_list_id?: string;
   output_format?: 'table' | 'json';
+  allowedTeamIds?: string[];
+  allowedSpaceIds?: string[];
 }
 
 function ensureConfigDir(): void {
@@ -141,6 +144,34 @@ export function getToken(): string | undefined {
 export function maskToken(token: string): string {
   if (token.length <= 8) return '****';
   return token.slice(0, 4) + '****' + token.slice(-4);
+}
+
+// --- Access restriction ---
+
+export function checkTeamAccess(teamId: string): void {
+  const config = loadConfig();
+  if (config.allowedTeamIds && config.allowedTeamIds.length > 0) {
+    if (!config.allowedTeamIds.includes(teamId)) {
+      throw new CliError(
+        `Access restricted: team ${teamId} is not in allowedTeamIds. Allowed: ${config.allowedTeamIds.join(', ')}`,
+        'ACCESS_RESTRICTED',
+        ExitCodes.ACCESS_RESTRICTED,
+      );
+    }
+  }
+}
+
+export function checkSpaceAccess(spaceId: string): void {
+  const config = loadConfig();
+  if (config.allowedSpaceIds && config.allowedSpaceIds.length > 0) {
+    if (!config.allowedSpaceIds.includes(spaceId)) {
+      throw new CliError(
+        `Access restricted: space ${spaceId} is not in allowedSpaceIds. Allowed: ${config.allowedSpaceIds.join(', ')}`,
+        'ACCESS_RESTRICTED',
+        ExitCodes.ACCESS_RESTRICTED,
+      );
+    }
+  }
 }
 
 // Re-export paths for testing

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,10 +12,23 @@ import { createTasksCommand } from './commands/tasks.js';
 import { createTimeTrackingCommand } from './commands/time-tracking.js';
 import { createViewsCommand } from './commands/views.js';
 import { createWebhooksCommand } from './commands/webhooks.js';
+import { checkTeamAccess, checkSpaceAccess } from './config.js';
+import { handleError } from './utils/errors.js';
 
 const program = new Command();
 
 program.name('clickup').description('ClickUp CLI - Manage ClickUp resources from the command line').version('0.1.0');
+
+// Access restriction: check --team-id and --space-id against allowlist before any command runs
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const opts = actionCommand.opts();
+  if (opts.teamId) {
+    checkTeamAccess(String(opts.teamId));
+  }
+  if (opts.spaceId) {
+    checkSpaceAccess(String(opts.spaceId));
+  }
+});
 
 program.addCommand(createAuthCommand());
 program.addCommand(createTasksCommand());
@@ -30,4 +43,8 @@ program.addCommand(createWebhooksCommand());
 program.addCommand(createTagsCommand());
 program.addCommand(createCustomFieldsCommand());
 
-program.parse();
+try {
+  program.parse();
+} catch (e) {
+  handleError(e);
+}

--- a/apps/cli/src/utils/errors.ts
+++ b/apps/cli/src/utils/errors.ts
@@ -19,6 +19,7 @@ export const ExitCodes = {
   API_ERROR: 6,
   RATE_LIMITED: 7,
   NETWORK_ERROR: 8,
+  ACCESS_RESTRICTED: 9,
 } as const;
 
 export function handleError(error: unknown): never {


### PR DESCRIPTION
## Summary
- `config.json` に `allowedTeamIds` / `allowedSpaceIds` を追加
- Commander の `preAction` hook で全コマンド実行前にチェック
- 許可外の team/space アクセスは `Access restricted` エラーで即拒否（exit code 9）
- 未設定時は従来通り全アクセス可能（後方互換）

## 設定例

```json
{"allowedTeamIds": ["9018139543"], "allowedSpaceIds": ["90180490909"]}
```

## 動作確認

```
$ clickup spaces list --team-id 25688359
Access restricted: team 25688359 is not in allowedTeamIds. Allowed: 9018139543

$ clickup spaces list --team-id 9018139543
{"spaces": [...]}  ✓
```

Closes #51

## Test plan
- [x] 許可 team/space で正常動作
- [x] 制限 team/space でクリーンなエラーメッセージ
- [x] 未設定時は全アクセス可能
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)